### PR TITLE
Feature/bypass zones

### DIFF
--- a/custom_components/dmp/__init__.py
+++ b/custom_components/dmp/__init__.py
@@ -25,6 +25,7 @@ from .const import (DOMAIN, LISTENER, CONF_PANEL_IP, LISTENER,
                     CONF_HOME_AREA, CONF_AWAY_AREA, DOMAIN, CONF_ZONES,
                     CONF_ZONE_NUMBER)
 from .dmp_codes import DMP_EVENTS, DMP_TYPES
+from .dmp_sender import DMPSender
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -128,6 +129,7 @@ class DMPPanel():
         self._panelPort = config.get(CONF_PANEL_REMOTE_PORT) or 2001
         self._panel_last_contact = None
         self._area = STATE_ALARM_DISARMED  # Default Value
+        self._dmpSender = DMPSender(self._ipAddress, self._panelPort, self._accountNumber, self._remoteKey)
         self._open_close_zones = {}
         self._battery_zones = {}
         self._trouble_zones = {}
@@ -290,33 +292,6 @@ class DMPPanel():
 
     def getAccountNumber(self):
         return self._accountNumber
-
-    async def connectAndSend(self, sToSend):
-        reader, writer = await asyncio.open_connection(self._ipAddress,
-                                                       self._panelPort)
-
-        # drop any existing connection
-        writer.write('@ {}!V0\r'.format(self._accountNumber).encode())
-        await writer.drain()
-        await asyncio.sleep(2)
-        # send auth string
-        writer.write('@ {}!V2{}\r'.format(self._accountNumber,
-                                          self._remoteKey).encode())
-        await writer.drain()
-        await asyncio.sleep(0.2)
-        # write single string to the receiver
-        writer.write('@ {}{}\r'.format(self._accountNumber, sToSend).encode())
-        await writer.drain()
-        await asyncio.sleep(0.2)
-        # disconnect
-        writer.write('@ {}!V0\r'.format(self._accountNumber).encode())
-        await writer.drain()
-        # close the socket
-        writer.close()
-        await writer.wait_closed()
-        data = await reader.read(256)
-        _LOGGER.debug("DMP: Received data after command: {}".format(data))
-
 
 class DMPListener():
     def __init__(self, hass, config):

--- a/custom_components/dmp/__init__.py
+++ b/custom_components/dmp/__init__.py
@@ -58,6 +58,7 @@ async def async_setup_entry(hass, entry) -> bool:
     )
     await hass.config_entries.async_forward_entry_setup(entry, "binary_sensor")
     await hass.config_entries.async_forward_entry_setup(entry, "sensor")
+    await hass.config_entries.async_forward_entry_setup(entry, "switch")
     return True
 
 

--- a/custom_components/dmp/alarm_control_panel.py
+++ b/custom_components/dmp/alarm_control_panel.py
@@ -113,12 +113,12 @@ class DMPArea(AlarmControlPanelEntity):
 
     async def async_alarm_disarm(self, code=None):
         """Send disarm command."""
-        await self._panel.connectAndSend('!O{},'.format(PANEL_ALL_ZONES))
+        await self._panel._dmpSender.disarm(PANEL_ALL_ZONES)
 
     async def async_alarm_arm_away(self, code=None):
         """Send arm away command."""
-        await self._panel.connectAndSend('!C{},YN'.format(PANEL_ALL_ZONES))
+        await self._panel._dmpSender.arm(PANEL_ALL_ZONES)
 
     async def async_alarm_arm_home(self, code=None):
-        """Send arm away command."""
-        await self._panel.connectAndSend('!C{},YN'.format(self._home_zone))
+        """Send arm home command."""
+        await self._panel._dmpSender.arm(self._home_zone)

--- a/custom_components/dmp/binary_sensor.py
+++ b/custom_components/dmp/binary_sensor.py
@@ -73,7 +73,8 @@ async def async_setup_entry(hass, config_entry, async_add_entities,):
     async_add_entities(openCloseZones, update_before_add=False)
     async_add_entities(batteryZones, update_before_add=False)
     async_add_entities(troubleZones, update_before_add=False)
-    async_add_entities(bypassZones, update_before_add=False)
+    # using bypass switch instead 
+    # async_add_entities(bypassZones, update_before_add=False)
     async_add_entities(alarmZones, update_before_add=False)
 
 

--- a/custom_components/dmp/config_flow.py
+++ b/custom_components/dmp/config_flow.py
@@ -175,7 +175,7 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
     ) -> Dict[str, Any]:
         """Manage the options for the custom component."""
         errors: Dict[str, str] = {}
-        entity_registry = await async_get(self.hass)
+        entity_registry = async_get(self.hass)
         entries = async_entries_for_config_entry(
             entity_registry, self.config_entry.entry_id
         )

--- a/custom_components/dmp/dmp_sender.py
+++ b/custom_components/dmp/dmp_sender.py
@@ -20,6 +20,7 @@ class DMPSender:
         await self.connectAndSend('!O{},'.format(zones))
 
     async def setBypass(self, zoneNum, enableBypass):
+        zoneNum = str(zoneNum).zfill(3)
         cmd = 'X' if enableBypass else 'Y'
         await self.connectAndSend('!{}{}'.format(cmd, zoneNum))
 

--- a/custom_components/dmp/dmp_sender.py
+++ b/custom_components/dmp/dmp_sender.py
@@ -1,0 +1,80 @@
+import asyncio
+import logging
+from enum import Enum
+
+_LOGGER = logging.getLogger(__name__)
+
+class DMPSender:
+    def __init__(self, ipAddr, port, accountNumber, remoteKey):
+        self.ipAddr = ipAddr
+        self.port = port
+        self.accountNumber = accountNumber
+        if len(self.accountNumber) < 5:
+            self.accountNumber = ' ' * (5 - len(self.accountNumber)) + self.accountNumber
+        self.remoteKey = remoteKey
+
+    async def arm(self, zones):
+        await self.connectAndSend('!C{},YN'.format(zones))
+
+    async def disarm(self, zones):
+        await self.connectAndSend('!O{},'.format(zones))
+
+    async def setBypass(self, zoneNum, enableBypass):
+        cmd = 'X' if enableBypass else 'Y'
+        await self.connectAndSend('!{}{}'.format(cmd, zoneNum))
+
+    async def connectAndSend(self, commands):
+        reader, writer = await asyncio.open_connection(self.ipAddr, self.port)
+        dropConnectionStr = '!V0'
+        sendAuthStr = '!V2{}'.format(self.remoteKey)
+
+        # original code had an initial drop followed by 2 second sleep - haven't had an issue without it...
+        # await self.sendCommand(writer, self.getEncodedPayload(dropConnectionStr))
+        await self.sendCommand(writer, self.getEncodedPayload(sendAuthStr))
+
+        if isinstance(commands, str):
+            await self.sendCommand(writer, self.getEncodedPayload(commands))
+        elif isinstance(commands, list):
+            for command in commands:
+                await self.sendCommand(writer, self.getEncodedPayload(command))
+
+        await self.sendCommand(writer, self.getEncodedPayload(dropConnectionStr))
+        writer.close()
+        await writer.wait_closed()
+        data = await reader.read()
+        ret = self.decodeResponse(data)
+        _LOGGER.debug("DMP: Decoded: {}".format(ret))
+        return ret
+
+    def getEncodedPayload(self, payload):
+        return '@{}{}\r'.format(self.accountNumber, payload).encode()
+
+    def decodeResponse(self, response):
+        _LOGGER.debug("DMP: Received data after command: {}".format(response))
+        responseLines = response.decode("utf-8").split('\x02')
+        for responseLine in responseLines:
+            messageType = responseLine[7:9]
+            if 'V' in messageType: # Auth/Drop Reply 
+                pass
+            elif 'C' in messageType: # Arm Reply 
+                return DMPResponse.charToEnum(responseLine[7:8])
+
+    async def sendCommand(self, writer, cmd):
+        # print("Sending cmd: {}".format(cmd))
+        _LOGGER.debug("DMP: Sending cmd: {}".format(cmd))
+        writer.write(cmd)
+        await writer.drain()
+        await asyncio.sleep(0.3) # need some sleep or read buffer will be empty
+
+class DMPResponse(Enum):
+    ACK = '+'
+    NAK = '-'
+    NA = ''
+
+    def charToEnum(char):
+        if char == DMPResponse.ACK.value:
+            return DMPResponse.ACK
+        elif char == DMPResponse.NAK.value:
+            return DMPResponse.NAK
+        else:
+            return DMPResponse.NA

--- a/custom_components/dmp/manifest.json
+++ b/custom_components/dmp/manifest.json
@@ -8,5 +8,5 @@
   "integration_type": "hub",
   "iot_class": "local_push",
   "requirements": [],
-  "version": "0.4.1"
+  "version": "0.4.2"
 }

--- a/custom_components/dmp/switch.py
+++ b/custom_components/dmp/switch.py
@@ -1,0 +1,108 @@
+from homeassistant.components.switch import (
+    SwitchEntity
+)
+from homeassistant.helpers.entity import DeviceInfo
+
+from .const import (DOMAIN, LISTENER, CONF_PANEL_ACCOUNT_NUMBER,
+                    CONF_ZONE_NAME, CONF_ZONE_NUMBER, CONF_ZONE_CLASS,
+                    CONF_ZONES)
+import logging
+
+
+_LOGGER = logging.getLogger(__name__)
+
+async def async_setup_entry(hass, config_entry, async_add_entities,):
+    _LOGGER.debug("Setting up bypass switches")
+    hass.data.setdefault(DOMAIN, {})
+    config = hass.data[DOMAIN][config_entry.entry_id]
+    # broken out from binary_sensor
+    bypassZones = []
+    for zone in config[CONF_ZONES]:
+        # allow all zones to be bypassed 
+        # if (
+        #     "window" in zone[CONF_ZONE_CLASS]
+        #     or "door" in zone[CONF_ZONE_CLASS]
+        #     or "glassbreak" in zone[CONF_ZONE_CLASS]
+        #     or "motion" in zone[CONF_ZONE_CLASS]
+        # ):
+            bypassZones.append(
+                DMPZoneBypassSwitch(
+                    hass, config_entry, zone
+                )
+            )
+    # Don't update before add or you have a race condition with the
+    # status zone.
+    async_add_entities(bypassZones, update_before_add=False)
+
+class DMPZoneBypassSwitch(SwitchEntity):
+    def __init__(self, hass, config_entry, entity_config):
+        self._hass = hass
+        self._config_entry = config_entry
+        config = hass.data[DOMAIN][config_entry.entry_id]
+        self._accountNum = config.get(CONF_PANEL_ACCOUNT_NUMBER)
+        self._listener = self._hass.data[DOMAIN][LISTENER]
+        self._device_name = entity_config.get(CONF_ZONE_NAME)
+        self._name = "%s Bypass" % entity_config.get(CONF_ZONE_NAME)
+        self._number = entity_config.get(CONF_ZONE_NUMBER)
+        self._device_class = "switch"
+        self._panel = self._listener.getPanels()[str(self._accountNum)]
+        self._state = False
+        zoneBypassObj = {
+            "zoneName": self._device_name,
+            "zoneNumber": str(self._number),
+            "zoneState": self._state
+            }
+        self._panel.updateBypassZone(str(self._number), zoneBypassObj)
+
+    async def async_added_to_hass(self):
+        _LOGGER.debug("Registering DMPZoneBypassSwitch Callback")
+        self._listener.register_callback(self.process_zone_callback)
+
+    async def async_will_remove_from_hass(self):
+        _LOGGER.debug("Removing DMPZoneBypassSwitch Callback")
+        self._listener.remove_callback(self.process_zone_callback)
+
+    async def process_zone_callback(self):
+        _LOGGER.debug("DMPZoneBypassSwitch Callback Executed")
+        self._state = self._panel.getBypassZone(self._number)["zoneState"]
+        self.async_write_ha_state()
+
+    @property
+    def device_name(self):
+        return self._device_name
+
+    @property
+    def name(self):
+        return self._name
+
+    @property
+    def is_on(self):
+        return self._state
+
+    @property
+    def device_class(self):
+        """Return the class of the device"""
+        _LOGGER.debug("Called DMPZoneBypassSwitch.device_class: {}"
+                      .format(self._device_class))
+        return self._device_class
+
+    @property
+    def unique_id(self):
+        return "dmp-%s-zone-%s-bypass-switch" % (self._accountNum, self._number)
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        """Return the device info."""
+        return DeviceInfo(
+            identifiers={
+                (DOMAIN, "dmp-%s-zone-%s" % (self._accountNum,
+                                             self._number))
+            },
+            via_device=(DOMAIN, "dmp-%s-panel" % (self._accountNum))
+        )
+
+    async def async_turn_on(self):
+        await self._panel._dmpSender.setBypass(self._number, True)
+
+    async def async_turn_off(self):
+        await self._panel._dmpSender.setBypass(self._number, False)


### PR DESCRIPTION
This PR replaces the HA `binary_sensor` that contained bypass status with a `switch` that can toggle bypass between enabled and reset. 
Allows all zones to be bypassed, unlike the previous `binary_sensor` that looked for window, door, glassbreak or motion. 

Also refactored connectAndSend into a standalone dmp_sender class. 

Known Issues:
Bypass resets after the alarm is disarmed, yet no incoming message that tells HA. This issue existed with the previous `binary_sensor` as well. Could reset all bypass zones when disarmed, but would rather add a status query (WIP). 