### PR TITLE
Feature/query status

### DIFF
--- a/custom_components/dmp/__init__.py
+++ b/custom_components/dmp/__init__.py
@@ -485,6 +485,7 @@ class DMPListener():
                     areaName = out[1]
                     if (systemCode == "OP"):  # Disarm
                         areaState = STATE_ALARM_DISARMED
+                        # do a manual status query - bypassed zones are reset but no message for it 
                         self._hass.async_create_task(self.updateStatus())
                     elif (systemCode == "CL"):  # Arm
                         if (areaNumber[1:] == self._home_area):
@@ -540,31 +541,26 @@ class DMPListener():
             status = await panel._dmpSender.status()
             areaStatus = status[0]
             zoneStatus = status[1]
-            _LOGGER.debug(panel._open_close_zones)
             for zone, zoneData in zoneStatus.items():
                 faultZone = {"zoneNumber": zone, "zoneState": True}
                 clearZone = {"zoneNumber": zone, "zoneState": False}
 
                 if zone in panel._open_close_zones:
-                    _LOGGER.debug("setting _open_close_zones " + zone)
                     if zoneData['status'] == 'Open' or zoneData['status'] == 'Short':
                         panel.updateOpenCloseZone(zone, faultZone)
                     elif zoneData['status'] == 'Normal':
                         panel.updateOpenCloseZone(zone, clearZone)
                 if zone in panel._bypass_zones:
-                    _LOGGER.debug("setting _bypass_zones " + zone)
                     if zoneData['status'] == 'Bypassed':
                         panel.updateBypassZone(zone, faultZone)
                     else:
                         panel.updateBypassZone(zone, clearZone)
                 if zone in panel._trouble_zones:
-                    _LOGGER.debug("setting _trouble_zones " + zone)
                     if zoneData['status'] == 'Missing':
                         panel.updateTroubleZone(zone, faultZone)
                     elif zoneData['status'] == 'Normal':
                         panel.updateTroubleZone(zone, clearZone)
                 if zone in panel._battery_zones:
-                    _LOGGER.debug("setting _battery_zones " + zone)
                     if zoneData['status'] == 'Low Battery':
                         panel.updateBatteryZone(zone, faultZone)
                     elif zoneData['status'] == 'Normal':

--- a/custom_components/dmp/__init__.py
+++ b/custom_components/dmp/__init__.py
@@ -59,6 +59,7 @@ async def async_setup_entry(hass, entry) -> bool:
     await hass.config_entries.async_forward_entry_setup(entry, "binary_sensor")
     await hass.config_entries.async_forward_entry_setup(entry, "sensor")
     await hass.config_entries.async_forward_entry_setup(entry, "switch")
+    hass.async_create_task(listener.updateStatus())
     return True
 
 
@@ -293,7 +294,7 @@ class DMPPanel():
 
     def getAccountNumber(self):
         return self._accountNumber
-
+    
 class DMPListener():
     def __init__(self, hass, config):
         self._hass = hass
@@ -483,6 +484,7 @@ class DMPListener():
                     areaName = out[1]
                     if (systemCode == "OP"):  # Disarm
                         areaState = STATE_ALARM_DISARMED
+                        self._hass.async_create_task(self.updateStatus())
                     elif (systemCode == "CL"):  # Arm
                         if (areaNumber[1:] == self._home_area):
                             # Make sure we're not already armed away
@@ -527,9 +529,48 @@ class DMPListener():
                 # update contact time last to ensure we only log contact time
                 # on a successful message
                 panel.updateContactTime(datetime.utcnow())
-                # call to update the hass object
-                for callback in self._callbacks:
-                    await callback()
+                await self.updateHASS()
             else:
                 _LOGGER.debug("Connection disconnected")
                 connected = False
+
+    async def updateStatus(self):
+        for panelName, panel in self._panels.items():
+            status = await panel._dmpSender.status()
+            areaStatus = status[0]
+            zoneStatus = status[1]
+            _LOGGER.debug(panel._open_close_zones)
+            for zone, zoneData in zoneStatus.items():
+                faultZone = {"zoneNumber": zone, "zoneState": True}
+                clearZone = {"zoneNumber": zone, "zoneState": False}
+
+                if zone in panel._open_close_zones:
+                    _LOGGER.debug("setting _open_close_zones " + zone)
+                    if zoneData['status'] == 'Open' or zoneData['status'] == 'Short':
+                        panel.updateOpenCloseZone(zone, faultZone)
+                    elif zoneData['status'] == 'Normal':
+                        panel.updateOpenCloseZone(zone, clearZone)
+                if zone in panel._bypass_zones:
+                    _LOGGER.debug("setting _bypass_zones " + zone)
+                    if zoneData['status'] == 'Bypassed':
+                        panel.updateBypassZone(zone, faultZone)
+                    else:
+                        panel.updateBypassZone(zone, clearZone)
+                if zone in panel._trouble_zones:
+                    _LOGGER.debug("setting _trouble_zones " + zone)
+                    if zoneData['status'] == 'Missing':
+                        panel.updateTroubleZone(zone, faultZone)
+                    elif zoneData['status'] == 'Normal':
+                        panel.updateTroubleZone(zone, clearZone)
+                if zone in panel._battery_zones:
+                    _LOGGER.debug("setting _battery_zones " + zone)
+                    if zoneData['status'] == 'Low Battery':
+                        panel.updateBatteryZone(zone, faultZone)
+                    elif zoneData['status'] == 'Normal':
+                        panel.updateBatteryZone(zone, clearZone)
+        await self.updateHASS()
+
+    async def updateHASS(self):
+        # call to update the hass object
+        for callback in self._callbacks:
+            await callback()

--- a/custom_components/dmp/__init__.py
+++ b/custom_components/dmp/__init__.py
@@ -59,6 +59,7 @@ async def async_setup_entry(hass, entry) -> bool:
     await hass.config_entries.async_forward_entry_setup(entry, "binary_sensor")
     await hass.config_entries.async_forward_entry_setup(entry, "sensor")
     await hass.config_entries.async_forward_entry_setup(entry, "switch")
+    await hass.config_entries.async_forward_entry_setup(entry, "button")
     hass.async_create_task(listener.updateStatus())
     return True
 

--- a/custom_components/dmp/alarm_control_panel.py
+++ b/custom_components/dmp/alarm_control_panel.py
@@ -15,7 +15,7 @@ from homeassistant.components.alarm_control_panel import (
 )
 from .const import (DOMAIN, LISTENER, CONF_PANEL_NAME,
                     CONF_PANEL_ACCOUNT_NUMBER, CONF_HOME_AREA,
-                    CONF_AWAY_AREA, PANEL_ALL_ZONES)
+                    CONF_AWAY_AREA, PANEL_ALL_AREAS)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -113,11 +113,11 @@ class DMPArea(AlarmControlPanelEntity):
 
     async def async_alarm_disarm(self, code=None):
         """Send disarm command."""
-        await self._panel._dmpSender.disarm(PANEL_ALL_ZONES)
+        await self._panel._dmpSender.disarm(PANEL_ALL_AREAS)
 
     async def async_alarm_arm_away(self, code=None):
         """Send arm away command."""
-        await self._panel._dmpSender.arm(PANEL_ALL_ZONES)
+        await self._panel._dmpSender.arm(PANEL_ALL_AREAS)
 
     async def async_alarm_arm_home(self, code=None):
         """Send arm home command."""

--- a/custom_components/dmp/alarm_control_panel.py
+++ b/custom_components/dmp/alarm_control_panel.py
@@ -60,7 +60,7 @@ class DMPArea(AlarmControlPanelEntity):
 
     async def process_area_callback(self):
         self.async_write_ha_state()
-        _LOGGER.debug("DMPArea Callback Executed")
+        # _LOGGER.debug("DMPArea Callback Executed")
 
     @property
     def name(self):

--- a/custom_components/dmp/binary_sensor.py
+++ b/custom_components/dmp/binary_sensor.py
@@ -113,7 +113,7 @@ class DMPZoneOpenClose(BinarySensorEntity):
         self._listener.remove_callback(self.process_zone_callback)
 
     async def process_zone_callback(self):
-        _LOGGER.debug("DMPZoneOpenClose Callback Executed")
+        # _LOGGER.debug("DMPZoneOpenClose Callback Executed")
         self._state = self._panel.getOpenCloseZone(self._number)["zoneState"]
         self.async_write_ha_state()
 
@@ -135,7 +135,7 @@ class DMPZoneOpenClose(BinarySensorEntity):
     @property
     def is_on(self):
         """Return the state of the device."""
-        _LOGGER.debug("Called DMPZoneOpenClose.is_on: {}".format(self._state))
+        # _LOGGER.debug("Called DMPZoneOpenClose.is_on: {}".format(self._state))
         return self._state
 
     @property
@@ -157,8 +157,8 @@ class DMPZoneOpenClose(BinarySensorEntity):
     @property
     def device_class(self):
         """Return the class of the device"""
-        _LOGGER.debug("Called DMPZoneOpenClose.device_class: {}"
-                      .format(self._device_class))
+        # _LOGGER.debug("Called DMPZoneOpenClose.device_class: {}"
+                    #   .format(self._device_class))
         return self._device_class
 
     @property
@@ -217,7 +217,7 @@ class DMPZoneBattery(BinarySensorEntity):
         self._listener.remove_callback(self.process_zone_callback)
 
     async def process_zone_callback(self):
-        _LOGGER.debug("DMPZoneBattery Callback Executed")
+        # _LOGGER.debug("DMPZoneBattery Callback Executed")
         self._state = self._panel.getBatteryZone(self._number)["zoneState"]
         self.async_write_ha_state()
 
@@ -239,7 +239,7 @@ class DMPZoneBattery(BinarySensorEntity):
     @property
     def is_on(self):
         """Return the state of the device."""
-        _LOGGER.debug("Called DMPZoneBattery.is_on: {}".format(self._state))
+        # _LOGGER.debug("Called DMPZoneBattery.is_on: {}".format(self._state))
         return self._state
 
     @property
@@ -254,8 +254,8 @@ class DMPZoneBattery(BinarySensorEntity):
     @property
     def device_class(self):
         """Return the class of the device"""
-        _LOGGER.debug("Called DMPZoneBattery.device_class: {}"
-                      .format(self._device_class))
+        # _LOGGER.debug("Called DMPZoneBattery.device_class: {}"
+                    #   .format(self._device_class))
         return self._device_class
 
     @property
@@ -316,7 +316,7 @@ class DMPZoneTrouble(BinarySensorEntity):
         self._listener.remove_callback(self.process_zone_callback)
 
     async def process_zone_callback(self):
-        _LOGGER.debug("DMPZoneTrouble Callback Executed")
+        # _LOGGER.debug("DMPZoneTrouble Callback Executed")
         self._state = self._panel.getTroubleZone(self._number)["zoneState"]
         self.async_write_ha_state()
 
@@ -338,7 +338,7 @@ class DMPZoneTrouble(BinarySensorEntity):
     @property
     def is_on(self):
         """Return the state of the device."""
-        _LOGGER.debug("Called DMPTroubleZone.is_on: {}".format(self._state))
+        # _LOGGER.debug("Called DMPTroubleZone.is_on: {}".format(self._state))
         return self._state
 
     @property
@@ -353,8 +353,8 @@ class DMPZoneTrouble(BinarySensorEntity):
     @property
     def device_class(self):
         """Return the class of the device"""
-        _LOGGER.debug("Called DMPTrouble.device_class: {}"
-                      .format(self._device_class))
+        # _LOGGER.debug("Called DMPTrouble.device_class: {}"
+                    #   .format(self._device_class))
         return self._device_class
 
     @property
@@ -415,7 +415,7 @@ class DMPZoneBypass(BinarySensorEntity):
         self._listener.remove_callback(self.process_zone_callback)
 
     async def process_zone_callback(self):
-        _LOGGER.debug("DMPZoneBypass Callback Executed")
+        # _LOGGER.debug("DMPZoneBypass Callback Executed")
         self._state = self._panel.getBypassZone(self._number)["zoneState"]
         self.async_write_ha_state()
 
@@ -437,7 +437,7 @@ class DMPZoneBypass(BinarySensorEntity):
     @property
     def is_on(self):
         """Return the state of the device."""
-        _LOGGER.debug("Called DMPZoneBypass.is_on: {}".format(self._state))
+        # _LOGGER.debug("Called DMPZoneBypass.is_on: {}".format(self._state))
         return self._state
 
     @property
@@ -452,8 +452,8 @@ class DMPZoneBypass(BinarySensorEntity):
     @property
     def device_class(self):
         """Return the class of the device"""
-        _LOGGER.debug("Called DMPZoneBypass.device_class: {}"
-                      .format(self._device_class))
+        # _LOGGER.debug("Called DMPZoneBypass.device_class: {}"
+                    #   .format(self._device_class))
         return self._device_class
 
     @property
@@ -514,7 +514,7 @@ class DMPZoneAlarm(BinarySensorEntity):
         self._listener.remove_callback(self.process_zone_callback)
 
     async def process_zone_callback(self):
-        _LOGGER.debug("DMPZoneAlarm Callback Executed")
+        # _LOGGER.debug("DMPZoneAlarm Callback Executed")
         self._state = self._panel.getAlarmZone(self._number)["zoneState"]
         self.async_write_ha_state()
 
@@ -536,7 +536,7 @@ class DMPZoneAlarm(BinarySensorEntity):
     @property
     def is_on(self):
         """Return the state of the device."""
-        _LOGGER.debug("Called DMPZoneAlarm.is_on: {}".format(self._state))
+        # _LOGGER.debug("Called DMPZoneAlarm.is_on: {}".format(self._state))
         return self._state
 
     @property
@@ -551,8 +551,8 @@ class DMPZoneAlarm(BinarySensorEntity):
     @property
     def device_class(self):
         """Return the class of the device"""
-        _LOGGER.debug("Called DMPZoneAlarm.device_class: {}"
-                      .format(self._device_class))
+        # _LOGGER.debug("Called DMPZoneAlarm.device_class: {}"
+                    #   .format(self._device_class))
         return self._device_class
 
     @property

--- a/custom_components/dmp/binary_sensor.py
+++ b/custom_components/dmp/binary_sensor.py
@@ -27,12 +27,12 @@ async def async_setup_entry(hass, config_entry, async_add_entities,):
             )
         for zone in config[CONF_ZONES]
     ]
-    # Only Windows and doors for Open/Close zones.
     openCloseZones = []
     for zone in config[CONF_ZONES]:
         if (
             "window" in zone[CONF_ZONE_CLASS]
             or "door" in zone[CONF_ZONE_CLASS]
+            or "default" in zone[CONF_ZONE_CLASS]
         ):
             openCloseZones.append(
                 DMPZoneOpenClose(
@@ -93,6 +93,8 @@ class DMPZoneOpenClose(BinarySensorEntity):
             self._device_class = "door"
         elif "window" in entity_config.get(CONF_ZONE_CLASS):
             self._device_class = "window"
+        else:
+            self._device_class = "sensors"
         self._panel = self._listener.getPanels()[str(self._accountNum)]
         self._state = False
         zoneOpenCloseObj = {

--- a/custom_components/dmp/button.py
+++ b/custom_components/dmp/button.py
@@ -1,0 +1,54 @@
+import logging
+
+from homeassistant.helpers.entity import DeviceInfo
+
+from homeassistant.components.button import ButtonEntity
+
+from .const import (DOMAIN, LISTENER, CONF_PANEL_NAME,
+                    CONF_PANEL_ACCOUNT_NUMBER)
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup_entry(hass, config_entry, async_add_entities,):
+    _LOGGER.info("Setting up alarm refresh button")
+    hass.data.setdefault(DOMAIN, {})
+    refreshButtons = []
+    refreshButtons.append(DMPRefreshStatusButton(hass, config_entry))
+    async_add_entities(refreshButtons, update_before_add=False)
+
+class DMPRefreshStatusButton(ButtonEntity):
+    def __init__(self, hass, config_entry):
+        self._hass = hass
+        self._config_entry = config_entry
+        config = hass.data[DOMAIN][config_entry.entry_id]
+        self._panel_name = config.get(CONF_PANEL_NAME)
+        self._accountNum = config.get(CONF_PANEL_ACCOUNT_NUMBER)
+        self._listener = self._hass.data[DOMAIN][LISTENER]
+        self._name = "Refresh Status"
+
+    async def async_press(self):
+        await self._listener.updateStatus()
+
+    @property
+    def name(self):
+        """Return the name of the device."""
+        return self._name
+
+    @property
+    def unique_id(self):
+        """Return unique ID"""
+        return "dmp-%s-panel-refresh-status" % self._accountNum
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        """Return the device info."""
+        return DeviceInfo(
+            identifiers={
+                (DOMAIN, "dmp-%s-panel" % self._accountNum)
+            },
+            name=self._panel_name,
+            manufacturer='Digital Monitoring Products',
+            via_device=(DOMAIN, "dmp-%s-panel" % (self._accountNum))
+
+        )

--- a/custom_components/dmp/button.py
+++ b/custom_components/dmp/button.py
@@ -9,7 +9,6 @@ from .const import (DOMAIN, LISTENER, CONF_PANEL_NAME,
 
 _LOGGER = logging.getLogger(__name__)
 
-
 async def async_setup_entry(hass, config_entry, async_add_entities,):
     _LOGGER.info("Setting up alarm refresh button")
     hass.data.setdefault(DOMAIN, {})
@@ -49,6 +48,4 @@ class DMPRefreshStatusButton(ButtonEntity):
             },
             name=self._panel_name,
             manufacturer='Digital Monitoring Products',
-            via_device=(DOMAIN, "dmp-%s-panel" % (self._accountNum))
-
         )

--- a/custom_components/dmp/const.py
+++ b/custom_components/dmp/const.py
@@ -48,4 +48,5 @@ BATTERY_LEVEL = "BatteryLevel"
 
 
 # Other Constants
-PANEL_ALL_ZONES = "010203"
+PANEL_AREA_COUNT = 3
+PANEL_ALL_AREAS = "010203"

--- a/custom_components/dmp/dmp_sender.py
+++ b/custom_components/dmp/dmp_sender.py
@@ -107,10 +107,9 @@ class StatusResponse():
         self.hasData = False
 
     def addToDict(self, targetDict, number, status, name):
-        targetDict[int(number)] = {
+        targetDict[number] = {
             'status': status,
             'name': name,
-            'number': number
         }
 
     def flush(self):
@@ -128,7 +127,7 @@ class StatusResponse():
             status = zone[4:5]
             name = zone[5:]
             if zoneType == 'A':
-                self.addToDict(self.areaDict, number, status, name)
+                self.addToDict(self.areaDict, number[1:], status, name)
             elif zoneType == 'L':
                 self.addToDict(self.zoneDict, number, status, name)
             else:
@@ -140,8 +139,8 @@ class StatusResponse():
             _LOGGER.debug("{}:".format(title))
             for number, details in sortedItems.items():
                 details['status'] = self.statusMap.get(details['status'], details['status'])
-                _LOGGER.debug("{} Number: {} ({}), Status: {}, Name: {}".format(
-                    title[:-1].title(), number, details['number'], details['status'], details['name']
+                _LOGGER.debug("{} Number: {}, Status: {}, Name: {}".format(
+                    title[:-1].title(), number, details['status'], details['name']
                 ))
         
         printItems("Areas", self.areaDict)

--- a/custom_components/dmp/dmp_sender.py
+++ b/custom_components/dmp/dmp_sender.py
@@ -26,7 +26,8 @@ class DMPSender:
         await self.connectAndSend('!{}{}'.format(cmd, zoneNum))
 
     async def status(self):
-        zoneQuery = ['?WB**Y001'] + ['?WB'] * PANEL_AREA_COUNT
+        # may need to send additional based on how many zones per area 
+        zoneQuery = ['?WB**Y001'] + ['?WB'] * (PANEL_AREA_COUNT + 1)
         return await self.connectAndSend(zoneQuery)
 
     async def connectAndSend(self, commands):

--- a/custom_components/dmp/sensor.py
+++ b/custom_components/dmp/sensor.py
@@ -79,7 +79,7 @@ class DMPZoneStatus(SensorEntity):
             item = device_registry.async_get_device(i)
 
     async def process_zone_callback(self):
-        _LOGGER.debug("DMPZoneStatus Callback Executed")
+        # _LOGGER.debug("DMPZoneStatus Callback Executed")
         self._state = self._panel.getStatusZone(self._number)["zoneState"]
         self.async_write_ha_state()
 
@@ -106,7 +106,7 @@ class DMPZoneStatus(SensorEntity):
     @property
     def state(self):
         """Return the state of the device."""
-        _LOGGER.debug("Called DMPZoneStatus.state: {}".format(self._state))
+        # _LOGGER.debug("Called DMPZoneStatus.state: {}".format(self._state))
         return self._state
 
     @property

--- a/custom_components/dmp/switch.py
+++ b/custom_components/dmp/switch.py
@@ -63,7 +63,7 @@ class DMPZoneBypassSwitch(SwitchEntity):
         self._listener.remove_callback(self.process_zone_callback)
 
     async def process_zone_callback(self):
-        _LOGGER.debug("DMPZoneBypassSwitch Callback Executed")
+        # _LOGGER.debug("DMPZoneBypassSwitch Callback Executed")
         self._state = self._panel.getBypassZone(self._number)["zoneState"]
         self.async_write_ha_state()
 
@@ -82,8 +82,8 @@ class DMPZoneBypassSwitch(SwitchEntity):
     @property
     def device_class(self):
         """Return the class of the device"""
-        _LOGGER.debug("Called DMPZoneBypassSwitch.device_class: {}"
-                      .format(self._device_class))
+        # _LOGGER.debug("Called DMPZoneBypassSwitch.device_class: {}"
+                    #   .format(self._device_class))
         return self._device_class
 
     @property


### PR DESCRIPTION
Adds a manual status query command. Used when panel is disarmed (fixes stuck bypass) and on startup. 
Adds a Home Assistant button tied to the panel for a manual status query (would have liked to write this to a HA entity that I could look at, but couldn't find one. would be a nice keep alive check since nothing built in atm). 