### PR TITLE
Support Instant Arm (Arm Night)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # DMP Integration for Home Assistant
 
-Integrate your DMP XR series alarn panel with Home Assistant. This integration provides arming control along with zone monitoring for doors and windows. 
+Integrate your DMP XR series alarn panel with Home Assistant. This integration provides arming control along with zone monitoring. 
 
 ## Important Info
 This integration is currently is in BETA. This means things may break or become unreliable. **Please Note: This integration is not designed to replace monitoring of your DMP panel by a UL certified monitoring center, and is solely designed to increase the ease of integrating the supervised sensors with other platforms**
@@ -8,32 +8,38 @@ This integration is currently is in BETA. This means things may break or become 
 ## Currently Supported Features
 
 ### Arming and Disarming
-This integration implements a simplified arming/disarming model from the panel's area model to a simple Arm Home/Arm Away model. This aligns better to how these panels are typically deployed in residential settings and also helps integrate better with Home Assistants model. It also facilitiates surfacing the alarm panel to other integrations like HomeKit. There are future plans to support arming with custom bypass.
+This integration implements a simplified arming/disarming model from the panel's area model to a simple Arm Home/Arm Away/Arm Night model. This aligns better to how these panels are typically deployed in residential settings and also helps integrate better with Home Assistants model. It also facilitiates surfacing the alarm panel to other integrations like HomeKit.
+
+#### Arm Types
+* Arm Home - arms the home area defined during platform configuration
+* Arm Away - arms areas 01, 02, 03 - not currently configurable 
+* Arm Night - arms the home area with the **instant** flag. This disables delay doors for exit and entry - alarm will trigger immediately if any zone is faulted. Shows as armed home from a status POV (haven't found a way to differentiate)
 
 ### Zone Monitoring
-This integration provides multiple binary sensors for each zone provided by the panel. These sensors include:
+This integration provides multiple entities for each zone provided by the panel. These include:
 
-* Window Open/Close
-* Door Open/Close
-* Alarm
-* Trouble
-* Low Battery 
-* Bypass
+* Window Open/Close (binary sensor)
+* Door Open/Close (binary sensor)
+* Alarm (binary sensor)
+* Trouble (binary sensor)
+* Low Battery (binary sensor)
+* Status (sensor - rollup of binary sensors for faults)
+* Bypass (switch - allow for enable/disable of bypass for each zone)
+
+The alarm panel itself has a *Refresh Status* button which will manually query the panel for current zone status. 
 
 It's important to note that in order for these sensor to be updated you must have "Zone Real-Time Status" enabled in the zone information menu for each zone you want real-time status for. Your dealer should be able to easily enable this for you. 
 
-Additionally the integration provides a consolidated status sensor that provides a high level overview of each zone. One point to note is all of these sensors are assumed in a good state when enabling the integration, this is due to the fact that we are unaware of a way to request the status of each zone at initialization time.
+Additionally the integration provides a consolidated status sensor that provides a high level overview of each zone. Zone status will be queried when the integration starts (may need to restart after adding new zones to query status). The current armed state is not queried - that is assumed to be disarmed on startup. 
 
 ## Setup Instructions
 This integration implements a Home Assistant configuration flow to simplify setup. To install, simply checkout this repo and copy `<REPO>/custom_components/dmp` to `<HASS INSTALL>/config/custom_components/dmp` and restart Home Assistant. Once installed the integration can be added from the control panel by searching for DMP.
 
 ## Planned Updates
-* Additional zone type support
-* Custom bypass arming
-* Bypassing individual zones
+* Track status of each area individually, support more than areas 01, 02 and 03
 * Validate configuration inputs
 * Simplification of platform code
-* Separation of panel specific code
+* Separation of panel specific listener code
 * Unit testing
 
 ## Credit

--- a/custom_components/dmp/alarm_control_panel.py
+++ b/custom_components/dmp/alarm_control_panel.py
@@ -79,7 +79,7 @@ class DMPArea(AlarmControlPanelEntity):
     @property
     def supported_features(self) -> int:
         """Return the list of supported features."""
-        return AlarmControlPanelEntityFeature.ARM_HOME | AlarmControlPanelEntityFeature.ARM_AWAY
+        return AlarmControlPanelEntityFeature.ARM_HOME | AlarmControlPanelEntityFeature.ARM_AWAY | AlarmControlPanelEntityFeature.ARM_NIGHT
 
     @property
     def code_arm_required(self):
@@ -115,8 +115,14 @@ class DMPArea(AlarmControlPanelEntity):
 
     async def async_alarm_arm_away(self, code=None):
         """Send arm away command."""
-        await self._panel._dmpSender.arm(PANEL_ALL_AREAS)
+        await self._panel._dmpSender.arm(PANEL_ALL_AREAS, False)
 
     async def async_alarm_arm_home(self, code=None):
         """Send arm home command."""
-        await self._panel._dmpSender.arm(self._home_zone)
+        await self._panel._dmpSender.arm(self._home_zone, False)
+
+    # arm night is just an arm home with no exit/entry delay
+    async def async_alarm_arm_night(self, code=None):
+        """Send arm night command."""
+        await self._panel._dmpSender.arm(self._home_zone, True)
+

--- a/custom_components/dmp/dmp_sender.py
+++ b/custom_components/dmp/dmp_sender.py
@@ -14,8 +14,12 @@ class DMPSender:
             self.accountNumber = ' ' * (5 - len(self.accountNumber)) + self.accountNumber
         self.remoteKey = remoteKey
 
-    async def arm(self, zones):
-        await self.connectAndSend('!C{},YN'.format(zones))
+    # instant removes all exit/entry delays. When a delay door is opened with instant arm - the delay is ignored and the alarm is triggered immediately 
+    async def arm(self, zones, instant):
+        instantFlag = 'N'
+        if instant:
+            instantFlag = 'Y'
+        await self.connectAndSend('!C{},YN{}'.format(zones, instantFlag))
 
     async def disarm(self, zones):
         await self.connectAndSend('!O{},'.format(zones))

--- a/custom_components/dmp/manifest.json
+++ b/custom_components/dmp/manifest.json
@@ -8,5 +8,5 @@
   "integration_type": "hub",
   "iot_class": "local_push",
   "requirements": [],
-  "version": "0.4.2"
+  "version": "0.4.3"
 }

--- a/custom_components/dmp/manifest.json
+++ b/custom_components/dmp/manifest.json
@@ -8,5 +8,5 @@
   "integration_type": "hub",
   "iot_class": "local_push",
   "requirements": [],
-  "version": "0.4.3"
+  "version": "0.5.1"
 }


### PR DESCRIPTION
Adds support for `AlarmControlPanelEntityFeature.ARM_NIGHT`. Implemented to arm the panel for home but with the `instant` flag sent to the panel. This flag causes the alarm to be triggered immediately on any zone fault, including delay doors. 

Note: the alarm panel card may not show arm night by default on your dashboard. Need to check it off in card configuration. 