### PR TITLE
Add status output to Refresh Status' extra attributes

### DIFF
--- a/custom_components/dmp/__init__.py
+++ b/custom_components/dmp/__init__.py
@@ -298,6 +298,7 @@ class DMPListener():
         self._port = config.get(CONF_PANEL_LISTEN_PORT)
         self._server = None
         self._panels = {}
+        self.statusAttributes = {}
         # callbacks to call when an event gets posted in
         self._callbacks = set()
 
@@ -558,7 +559,22 @@ class DMPListener():
                         panel.updateBatteryZone(zone, faultZone)
                     elif zoneData['status'] == 'Normal':
                         panel.updateBatteryZone(zone, clearZone)
+        self.setStatusAttributes(areaStatus, zoneStatus)
         await self.updateHASS()
+
+    def setStatusAttributes(self, areaStatus, zoneStatus):
+        attr = {}
+        attr[datetime.now().strftime("%Y-%m-%d %H:%M:%S") ] = ''
+        attr['Areas:'] = ''
+        for area in dict(sorted(areaStatus.items())):
+            attr['Area: ' + area + ' - ' + areaStatus[area]['name']] = areaStatus[area]['status']
+        attr['Zones:'] = ''
+        for zone in dict(sorted(zoneStatus.items())):
+            attr['Zone: ' + zone + ' - ' + zoneStatus[zone]['name']] = zoneStatus[zone]['status']
+        self.statusAttributes = attr
+
+    def getStatusAttributes(self):
+        return self.statusAttributes
 
     async def updateHASS(self):
         # call to update the hass object

--- a/custom_components/dmp/button.py
+++ b/custom_components/dmp/button.py
@@ -26,6 +26,15 @@ class DMPRefreshStatusButton(ButtonEntity):
         self._listener = self._hass.data[DOMAIN][LISTENER]
         self._name = "Refresh Status"
 
+    async def async_added_to_hass(self):
+        self._listener.register_callback(self.process_zone_callback)
+
+    async def async_will_remove_from_hass(self):
+        self._listener.remove_callback(self.process_zone_callback)
+
+    async def process_zone_callback(self):
+        self.async_write_ha_state()
+
     async def async_press(self):
         await self._listener.updateStatus()
 
@@ -49,3 +58,8 @@ class DMPRefreshStatusButton(ButtonEntity):
             name=self._panel_name,
             manufacturer='Digital Monitoring Products',
         )
+
+    @property
+    def extra_state_attributes(self):
+        """Return the state attributes."""
+        return self._listener.getStatusAttributes()

--- a/custom_components/dmp/manifest.json
+++ b/custom_components/dmp/manifest.json
@@ -8,5 +8,5 @@
   "integration_type": "hub",
   "iot_class": "local_push",
   "requirements": [],
-  "version": "0.5.2"
+  "version": "0.5.3"
 }


### PR DESCRIPTION
Parses and displays the raw results from the status request, looks something like this within the refresh status button:

![image](https://github.com/user-attachments/assets/37e2a16c-66f1-495b-b82d-6058442d5054)
