### PR TITLE
Temporary Multi-Homed Networking Fix

### DIFF
--- a/custom_components/dmp/__init__.py
+++ b/custom_components/dmp/__init__.py
@@ -52,7 +52,9 @@ async def async_setup_entry(hass, entry) -> bool:
 
 async def async_unload_entry(hass, entry):
     _LOGGER.debug("Unloading entry.")
-    listener = hass.data[DOMAIN][LISTENER]
+    # listener = hass.data[DOMAIN][LISTENER]
+    # Temporary fix to support HomeAssistant boxes with multiple NICs. 
+    listener = "0.0.0.0"
     unload_ok = await hass.config_entries.async_unload_platforms(
         entry, PLATFORMS
         ) and await listener.stop()


### PR DESCRIPTION
Temporary fix for Issue #46. Switching listener to 0.0.0.0 to unblock use case until this can be more thoroughly fixed with the configuration flow. 