### PR TITLE
fault a trouble zone if in the Short state

### DIFF
--- a/custom_components/dmp/__init__.py
+++ b/custom_components/dmp/__init__.py
@@ -535,7 +535,7 @@ class DMPListener():
                     else:
                         panel.updateBypassZone(zone, clearZone)
                 if zone in panel._trouble_zones:
-                    if zoneData['status'] == 'Missing':
+                    if zoneData['status'] == 'Missing' or zoneData['status'] == 'Short':
                         panel.updateTroubleZone(zone, faultZone)
                     elif zoneData['status'] == 'Normal':
                         panel.updateTroubleZone(zone, clearZone)


### PR DESCRIPTION
When a trouble device was faulted by being in the "Short" state, the trouble or main status entity did not update to reflect this. 
The panel did go to triggered though. 