### PR TITLE
Remove unsupported homeassistant key from manifest

### DIFF
--- a/custom_components/dmp/manifest.json
+++ b/custom_components/dmp/manifest.json
@@ -5,7 +5,6 @@
   "config_flow": true,
   "dependencies": ["alarm_control_panel", "network"],
   "documentation": "https://github.com/amattas/hass-dmp",
-  "homeassistant": "2025.12.0",
   "integration_type": "hub",
   "iot_class": "local_push",
   "requirements": ["pydmp==1.0.0b1"],


### PR DESCRIPTION
## Summary
- Removes the `homeassistant` key from `manifest.json` which is no longer allowed by the latest hassfest validator, causing CI failures

## Test plan
- [ ] Verify hassfest workflow passes