### PR TITLE
docs: drop beta caution; document the actual config flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 Integrate your DMP XR series alarn panel with Home Assistant. This integration provides arming control along with zone monitoring. 
 
 ## Important Info
-This integration is currently is in BETA. This means things may break or become unreliable. **Please Note: This integration is not designed to replace monitoring of your DMP panel by a UL certified monitoring center, and is solely designed to increase the ease of integrating the supervised sensors with other platforms**
+**Please Note: This integration is not designed to replace monitoring of your DMP panel by a UL certified monitoring center, and is solely designed to increase the ease of integrating the supervised sensors with other platforms.**
 
 ## Currently Supported Features
 

--- a/website/docs/guide/installation.md
+++ b/website/docs/guide/installation.md
@@ -25,7 +25,48 @@ for exactly where each value lives in panel programming.
 
 2. Restart Home Assistant.
 3. Add the integration from **Settings → Devices & Services** by searching for
-   **DMP**, and follow the config flow.
+   **DMP**, and follow the config flow below.
+
+## The config flow
+
+### Step 1 — DMP Panel Configuration
+
+| Field | Default | What to enter |
+|---|---|---|
+| Panel Name | `DMP XR150` | A friendly name for the device in Home Assistant |
+| Panel Hostname/IP Address | `192.168.1.2` | The panel's network address |
+| Panel Port | `8011` | The panel's **Network Programming Port** (Remote Options) — set them to match |
+| Listener Port | `8001` | The port Home Assistant listens on for panel events — point the panel's **PC Log Reports → Net Port** here |
+| Account Number | — | The panel's account number (Communication → Account Number) |
+| Panel Key | — | The panel's **Remote Key** (Remote Options); leave empty if the panel's key is blank |
+
+### Step 2 — DMP Arming Configuration
+
+| Field | Default | What to enter |
+|---|---|---|
+| Home Zone | `01` | The area armed by **Arm Home** / **Arm Night** (digits only) |
+| Away Zone | `02` | Shown for reference — **Arm Away** arms areas 01–03 |
+
+On most panels area `01` is the perimeter (use it for home arming) and
+`02`/`03` are interior areas. Arming home arms only the area you specify;
+disarming and arming away affect all areas.
+
+### Step 3 — DMP Zone Configuration
+
+Add each panel zone you want entities for — the step repeats while
+**"Add another zone?"** is checked:
+
+| Field | What to enter |
+|---|---|
+| Zone Name | The entity name, e.g. `Front Door` |
+| Zone Number | The zone number as programmed in the panel (digits only) |
+| Zone Device Class | Pick the device type — Door, Window, Motion Detector, Glass Break Detector, Siren, or Smoke Detector (each in wired or battery-powered variants). This controls which entities the zone gets. |
+
+### Adding or removing zones later
+
+Open the integration's **Configure** option (Settings → Devices & Services →
+DMP → Configure): the **Manage Zones** screen lets you uncheck existing zones
+to remove them or add a new one — no reinstall needed.
 
 ## Zone status prerequisites
 

--- a/website/docs/index.md
+++ b/website/docs/index.md
@@ -13,10 +13,9 @@ Serial 3 push protocol (powered by [pydmp](https://amattas.github.io/pydmp/)).
 
 :::caution
 
-This integration is in **beta** — things may break or become unreliable. It is
-not designed to replace monitoring by a UL-certified monitoring center; it
-exists to make the panel's supervised sensors easy to integrate with other
-platforms.
+This integration is not designed to replace monitoring by a UL-certified
+monitoring center; it exists to make the panel's supervised sensors easy to
+integrate with other platforms.
 
 :::
 

--- a/website/versioned_docs/version-1.0.1/guide/installation.md
+++ b/website/versioned_docs/version-1.0.1/guide/installation.md
@@ -25,7 +25,48 @@ for exactly where each value lives in panel programming.
 
 2. Restart Home Assistant.
 3. Add the integration from **Settings → Devices & Services** by searching for
-   **DMP**, and follow the config flow.
+   **DMP**, and follow the config flow below.
+
+## The config flow
+
+### Step 1 — DMP Panel Configuration
+
+| Field | Default | What to enter |
+|---|---|---|
+| Panel Name | `DMP XR150` | A friendly name for the device in Home Assistant |
+| Panel Hostname/IP Address | `192.168.1.2` | The panel's network address |
+| Panel Port | `8011` | The panel's **Network Programming Port** (Remote Options) — set them to match |
+| Listener Port | `8001` | The port Home Assistant listens on for panel events — point the panel's **PC Log Reports → Net Port** here |
+| Account Number | — | The panel's account number (Communication → Account Number) |
+| Panel Key | — | The panel's **Remote Key** (Remote Options); leave empty if the panel's key is blank |
+
+### Step 2 — DMP Arming Configuration
+
+| Field | Default | What to enter |
+|---|---|---|
+| Home Zone | `01` | The area armed by **Arm Home** / **Arm Night** (digits only) |
+| Away Zone | `02` | Shown for reference — **Arm Away** arms areas 01–03 |
+
+On most panels area `01` is the perimeter (use it for home arming) and
+`02`/`03` are interior areas. Arming home arms only the area you specify;
+disarming and arming away affect all areas.
+
+### Step 3 — DMP Zone Configuration
+
+Add each panel zone you want entities for — the step repeats while
+**"Add another zone?"** is checked:
+
+| Field | What to enter |
+|---|---|
+| Zone Name | The entity name, e.g. `Front Door` |
+| Zone Number | The zone number as programmed in the panel (digits only) |
+| Zone Device Class | Pick the device type — Door, Window, Motion Detector, Glass Break Detector, Siren, or Smoke Detector (each in wired or battery-powered variants). This controls which entities the zone gets. |
+
+### Adding or removing zones later
+
+Open the integration's **Configure** option (Settings → Devices & Services →
+DMP → Configure): the **Manage Zones** screen lets you uncheck existing zones
+to remove them or add a new one — no reinstall needed.
 
 ## Zone status prerequisites
 

--- a/website/versioned_docs/version-1.0.1/index.md
+++ b/website/versioned_docs/version-1.0.1/index.md
@@ -13,10 +13,9 @@ Serial 3 push protocol (powered by [pydmp](https://amattas.github.io/pydmp/)).
 
 :::caution
 
-This integration is in **beta** — things may break or become unreliable. It is
-not designed to replace monitoring by a UL-certified monitoring center; it
-exists to make the panel's supervised sensors easy to integrate with other
-platforms.
+This integration is not designed to replace monitoring by a UL-certified
+monitoring center; it exists to make the panel's supervised sensors easy to
+integrate with other platforms.
 
 :::
 


### PR DESCRIPTION
Two doc corrections:

1. **Beta is over** — the beta caution came straight from the README, which still claimed it; removed from both (the UL-monitoring disclaimer stays, since it's a safety statement, not a maturity statement).
2. **The installation guide now documents the real config flow**, field-for-field from `config_flow.py` + `translations/en.json`: all six Step-1 fields with defaults and their matching panel-programming locations, the arming-area step (01 perimeter for home; away arms 01–03), the repeating zone step with the actual device-class dropdown options, and the Manage Zones options flow for changing zones later without reinstalling.

Synced into the 1.0.1 docs snapshot; build green.